### PR TITLE
For compatibility with rideable

### DIFF
--- a/module/src/rotation.js
+++ b/module/src/rotation.js
@@ -82,7 +82,8 @@ function rotationFromPositionDelta(deltaX, deltaY, offset){
 async function rotateTokenOnPreUpdate(tokenDocument, change, options, userId) {
     const cont = (
         userId === game.user.id &&
-        shouldRotate(tokenDocument)
+        shouldRotate(tokenDocument) &&
+		!options.RidingMovement //for rideable compatibility
     )
     if (!cont){
         return;


### PR DESCRIPTION
There was a small problem where the rotation of piloting tokens and piloted tokens would mix, causing some strange behaviour, this patch will simply turn of the auto rotate for movements caused directly by rideable, letting rideable take care of the rotation.